### PR TITLE
Faraday version update

### DIFF
--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -26,9 +26,7 @@ describe Faraday::Response do
       end
 
       it "should raise #{exception.name} error" do
-        lambda do
-          @client.talks
-        end.should raise_error(exception)
+        expect{ @client.talks }.to raise_exception(exception)
       end
     end
   end

--- a/spec/ted_api/client/countries_spec.rb
+++ b/spec/ted_api/client/countries_spec.rb
@@ -13,7 +13,7 @@ describe TedApi::Client::Countries do
     stub_get("countries.json?api-key=foo").
       to_return(:body => fixture("countries.json"))
     response = @client.countries
-    response.states.first.state.name.should == 'Afghanistan'
+    expect(response.states.first.state.name).to eq('Afghanistan')
   end 
   
   it "should return a specific Ted event in json" do
@@ -21,7 +21,7 @@ describe TedApi::Client::Countries do
     stub_get("countries/1.json?api-key=foo").
       to_return(:body => fixture("country.json"))
     response = @client.countries('1')
-    response.state.name.should == 'Afghanistan'
+    expect(response.state.name).to eq('Afghanistan')
   end 
   
   # XML Tests:
@@ -31,7 +31,7 @@ describe TedApi::Client::Countries do
     stub_get("countries.xml?api-key=foo").
       to_return(:body => fixture("countries.xml"))
     response = @client.countries
-    response.counts.total.should == "248"
+    expect(response.counts.total).to eq("248")
   end
   
   it "should return a specific Ted event in xml" do
@@ -39,7 +39,7 @@ describe TedApi::Client::Countries do
     stub_get("countries/1.xml?api-key=foo").
       to_return(:body => fixture("country.xml"))
     response = @client.countries('1')
-    response.state.name.should == 'Afghanistan'
+    expect(response.state.name).to eq('Afghanistan')
   end
   
   

--- a/spec/ted_api/client/events_spec.rb
+++ b/spec/ted_api/client/events_spec.rb
@@ -13,7 +13,7 @@ describe TedApi::Client::Events do
     stub_get("events.json?api-key=foo").
       to_return(:body => fixture("events.json"))
     response = @client.events
-    response.counts.total.should == 211
+    expect(response.counts.total).to eq(211)
   end 
   
   it "should return a specific Ted event in json" do
@@ -21,7 +21,7 @@ describe TedApi::Client::Events do
     stub_get("events/1.json?api-key=foo").
       to_return(:body => fixture("event.json"))
     response = @client.events('1')
-    response.event.name.should == 'TED2008'
+    expect(response.event.name).to eq('TED2008')
   end 
   
   # XML Tests:
@@ -31,7 +31,7 @@ describe TedApi::Client::Events do
     stub_get("events.xml?api-key=foo").
       to_return(:body => fixture("events.xml"))
     response = @client.events
-    response.counts.total.should == "211"
+    expect(response.counts.total).to eq("211")
   end
   
   it "should return a specific Ted event in xml" do
@@ -39,7 +39,7 @@ describe TedApi::Client::Events do
     stub_get("events/1.xml?api-key=foo").
       to_return(:body => fixture("event.xml"))
     response = @client.events('1')
-    response.event.name.should == 'TED2008'
+    expect(response.event.name).to eq('TED2008')
   end
   
   

--- a/spec/ted_api/client/languages_spec.rb
+++ b/spec/ted_api/client/languages_spec.rb
@@ -13,7 +13,7 @@ describe TedApi::Client::Languages do
     stub_get("languages.json?api-key=foo").
       to_return(:body => fixture("languages.json"))
     response = @client.languages
-    response.languages.first.language.language_code.should == 'af'
+    expect(response.languages.first.language.language_code).to eq('af')
   end 
   
   it "should return a specific Ted event in json" do
@@ -21,7 +21,7 @@ describe TedApi::Client::Languages do
     stub_get("languages/af.json?api-key=foo").
       to_return(:body => fixture("language.json"))
     response = @client.languages('af')
-    response.language.language_code.should == 'af'
+    expect(response.language.language_code).to eq('af')
   end 
   
   # XML Tests:
@@ -31,7 +31,7 @@ describe TedApi::Client::Languages do
     stub_get("languages.xml?api-key=foo").
       to_return(:body => fixture("languages.xml"))
     response = @client.languages
-    response.languages.first.first.should == 'language'
+    expect(response.languages.first.first).to eq('language')
   end
   
   it "should return a specific Ted event in xml" do
@@ -39,7 +39,7 @@ describe TedApi::Client::Languages do
     stub_get("languages/af.xml?api-key=foo").
       to_return(:body => fixture("language.xml"))
     response = @client.languages('af')
-    response.language.language_code.should == 'af'
+    expect(response.language.language_code).to eq('af')
   end
   
   

--- a/spec/ted_api/client/quotes_spec.rb
+++ b/spec/ted_api/client/quotes_spec.rb
@@ -13,7 +13,7 @@ describe TedApi::Client::Quotes do
     stub_get("quotes.json?api-key=foo").
       to_return(:body => fixture("quotes.json"))
     response = @client.quotes
-    response.quotes.first.quote.slug.should == 'around_the_world_women_and_children_spend_40_billion_hours'
+    expect(response.quotes.first.quote.slug).to eq('around_the_world_women_and_children_spend_40_billion_hours')
   end 
   
   it "should return a specific Ted quote in json" do
@@ -21,7 +21,7 @@ describe TedApi::Client::Quotes do
     stub_get("quotes/1.json?api-key=foo").
       to_return(:body => fixture("quote.json"))
     response = @client.quotes('1')
-    response.quote.slug.should == 'around_the_world_women_and_children_spend_40_billion_hours'
+    expect(response.quote.slug).to eq('around_the_world_women_and_children_spend_40_billion_hours')
   end 
   
   # XML Tests:
@@ -31,7 +31,7 @@ describe TedApi::Client::Quotes do
     stub_get("quotes.xml?api-key=foo").
       to_return(:body => fixture("quotes.xml"))
     response = @client.quotes
-    response.quotes.first.first.should == 'quote'
+    expect(response.quotes.first.first).to eq('quote')
   end
   
   it "should return a specific Ted event in xml" do
@@ -39,7 +39,7 @@ describe TedApi::Client::Quotes do
     stub_get("quotes/1.xml?api-key=foo").
       to_return(:body => fixture("quote.xml"))
     response = @client.quotes('1')
-    response.quote.slug.should == 'around_the_world_women_and_children_spend_40_billion_hours'
+    expect(response.quote.slug).to eq('around_the_world_women_and_children_spend_40_billion_hours')
   end
   
   

--- a/spec/ted_api/client/rating_words_spec.rb
+++ b/spec/ted_api/client/rating_words_spec.rb
@@ -13,7 +13,7 @@ describe TedApi::Client::RatingWords do
     stub_get("rating_words.json?api-key=foo").
       to_return(:body => fixture("rating_words.json"))
     response = @client.rating_words
-    response.rating_words.first.rating_word.name.should == 'Beautiful'
+    expect(response.rating_words.first.rating_word.name).to eq('Beautiful')
   end 
   
   it "should return a specific rating word in json" do
@@ -21,7 +21,7 @@ describe TedApi::Client::RatingWords do
     stub_get("rating_words/1.json?api-key=foo").
       to_return(:body => fixture("rating_word.json"))
     response = @client.rating_words('1')
-    response.rating_word.name.should == 'Beautiful'
+    expect(response.rating_word.name).to eq('Beautiful')
   end 
   
   # XML Tests:
@@ -31,7 +31,7 @@ describe TedApi::Client::RatingWords do
     stub_get("rating_words.xml?api-key=foo").
       to_return(:body => fixture("rating_words.xml"))
     response = @client.rating_words
-    response.rating_words.first.first.should == 'rating_word'
+    expect(response.rating_words.first.first).to eq('rating_word')
   end
   
   it "should return a specific rating word in xml" do
@@ -39,7 +39,7 @@ describe TedApi::Client::RatingWords do
     stub_get("rating_words/1.xml?api-key=foo").
       to_return(:body => fixture("rating_word.xml"))
     response = @client.rating_words('1')
-    response.rating_word.name.should == 'Beautiful'
+    expect(response.rating_word.name).to eq('Beautiful')
   end
   
   

--- a/spec/ted_api/client/speakers_spec.rb
+++ b/spec/ted_api/client/speakers_spec.rb
@@ -13,7 +13,7 @@ describe TedApi::Client::Speakers do
     stub_get("speakers.json?api-key=foo").
       to_return(:body => fixture("speakers.json"))
     response = @client.speakers
-    response.speakers.first.speaker.description.should == 'Climate-change prophet'
+    expect(response.speakers.first.speaker.description).to eq('Climate-change prophet')
   end 
   
   it "should return a specific speaker in json" do
@@ -21,7 +21,7 @@ describe TedApi::Client::Speakers do
     stub_get("speakers/2.json?api-key=foo").
       to_return(:body => fixture("speaker.json"))
     response = @client.speakers('2')
-    response.speaker.description.should == 'Climate-change prophet'
+    expect(response.speaker.description).to eq('Climate-change prophet')
   end 
   
   # XML Tests:
@@ -31,7 +31,7 @@ describe TedApi::Client::Speakers do
     stub_get("speakers.xml?api-key=foo").
       to_return(:body => fixture("speakers.xml"))
     response = @client.speakers
-    response.speakers.first.first.should == 'speaker'
+    expect(response.speakers.first.first).to eq('speaker')
   end
   
   it "should return a specific theme in xml" do
@@ -39,7 +39,7 @@ describe TedApi::Client::Speakers do
     stub_get("speakers/2.xml?api-key=foo").
       to_return(:body => fixture("speaker.xml"))
     response = @client.speakers('2')
-    response.speaker.description.should == 'Climate-change prophet'
+    expect(response.speaker.description).to eq('Climate-change prophet')
   end
   
   

--- a/spec/ted_api/client/tags_spec.rb
+++ b/spec/ted_api/client/tags_spec.rb
@@ -13,7 +13,7 @@ describe TedApi::Client::Tags do
     stub_get("tags.json?api-key=foo").
       to_return(:body => fixture("tags.json"))
     response = @client.tags
-    response.tags.first.tag.name.should == 'standard'
+    expect(response.tags.first.tag.name).to eq('standard')
   end 
   
   it "should return a specific tag in json" do
@@ -21,7 +21,7 @@ describe TedApi::Client::Tags do
     stub_get("tags/1.json?api-key=foo").
       to_return(:body => fixture("tag.json"))
     response = @client.tags('1')
-    response.tag.name.should == 'standard'
+    expect(response.tag.name).to eq('standard')
   end 
   
   # XML Tests:
@@ -31,7 +31,7 @@ describe TedApi::Client::Tags do
     stub_get("tags.xml?api-key=foo").
       to_return(:body => fixture("tags.xml"))
     response = @client.tags
-    response.tags.first.first.should == 'tag'
+    expect(response.tags.first.first).to eq('tag')
   end
   
   it "should return a specific theme in xml" do
@@ -39,7 +39,7 @@ describe TedApi::Client::Tags do
     stub_get("tags/1.xml?api-key=foo").
       to_return(:body => fixture("tag.xml"))
     response = @client.tags('1')
-    response.tag.name.should == 'standard'
+    expect(response.tag.name).to eq('standard')
   end
   
   

--- a/spec/ted_api/client/talks_spec.rb
+++ b/spec/ted_api/client/talks_spec.rb
@@ -13,7 +13,7 @@ describe TedApi::Client::Talks do
     stub_get("talks.json?api-key=foo").
       to_return(:body => fixture("talks.json"))
     response = @client.talks
-    response.talks.first.talk.name.should == "Al Gore: Averting the climate crisis" 
+    expect(response.talks.first.talk.name).to eq("Al Gore: Averting the climate crisis" )
   end 
   
   it "should return Ted talks in json raw" do
@@ -21,7 +21,7 @@ describe TedApi::Client::Talks do
     stub_get("talks.json?api-key=foo").
       to_return(:body => fixture("talks.json"))
     response = @client.talks(nil, {}, true)
-    response.class.name.should == "Faraday::Response" 
+    expect(response.class.name).to eq("Faraday::Response" )
   end
   
   it "should return a specific Ted talk in json" do
@@ -29,7 +29,7 @@ describe TedApi::Client::Talks do
     stub_get("talks/1.json?api-key=foo").
       to_return(:body => fixture("talk.json"))
     response = @client.talks('1')
-    response.talk.name.should == "Al Gore: Averting the climate crisis" 
+    expect(response.talk.name).to eq("Al Gore: Averting the climate crisis" )
   end 
   
   it "should return speakers for a specific Ted talk in json" do
@@ -37,7 +37,7 @@ describe TedApi::Client::Talks do
     stub_get("talks/1/speakers.json?api-key=foo").
       to_return(:body => fixture("speakers_by_talk.json"))
     response = @client.speakers_by_talk('1')
-    response.speakers.first.speaker.description.should == 'Climate-change prophet'
+    expect(response.speakers.first.speaker.description).to eq('Climate-change prophet')
   end
   
   it "should return speakers for a specific Ted talk in json" do
@@ -45,7 +45,7 @@ describe TedApi::Client::Talks do
     stub_get("talks/1/subtitles.json?api-key=foo").
       to_return(:body => fixture("subtitles.json"))
     response = @client.subtitles('1')
-    response.first.first.should == "0"
+    expect(response.first.first).to eq("0")
   end
   
   # XML Tests:
@@ -55,7 +55,7 @@ describe TedApi::Client::Talks do
     stub_get("talks.xml?api-key=foo").
       to_return(:body => fixture("talks.xml"))
     response = @client.talks
-    response.talks.talk.first.name.should == "Al Gore: Averting the climate crisis" 
+    expect(response.talks.talk.first.name).to eq("Al Gore: Averting the climate crisis" )
   end
   
   it "should return Ted talks in xml raw" do
@@ -63,7 +63,7 @@ describe TedApi::Client::Talks do
     stub_get("talks.xml?api-key=foo").
       to_return(:body => fixture("talks.xml"))
     response = @client.talks(nil, {}, true)
-    response.class.name.should == "Faraday::Response" 
+    expect(response.class.name).to eq("Faraday::Response" )
   end
   
   it "should return a specific Ted talk in xml" do
@@ -71,7 +71,7 @@ describe TedApi::Client::Talks do
     stub_get("talks/1.xml?api-key=foo").
       to_return(:body => fixture("talk.xml"))
     response = @client.talks('1')
-    response.talk.name.should == "Al Gore: Averting the climate crisis" 
+    expect(response.talk.name).to eq("Al Gore: Averting the climate crisis" )
   end
   
   

--- a/spec/ted_api/client/themes_spec.rb
+++ b/spec/ted_api/client/themes_spec.rb
@@ -13,7 +13,7 @@ describe TedApi::Client::Themes do
     stub_get("themes.json?api-key=foo").
       to_return(:body => fixture("themes.json"))
     response = @client.themes
-    response.themes.first.theme.slug.should == 'the_creative_spark'
+    expect(response.themes.first.theme.slug).to eq('the_creative_spark')
   end 
   
   it "should return a specific theme in json" do
@@ -21,7 +21,7 @@ describe TedApi::Client::Themes do
     stub_get("themes/1.json?api-key=foo").
       to_return(:body => fixture("theme.json"))
     response = @client.themes('1')
-    response.theme.slug.should == 'the_creative_spark'
+    expect(response.theme.slug).to eq('the_creative_spark')
   end 
   
   # XML Tests:
@@ -31,7 +31,7 @@ describe TedApi::Client::Themes do
     stub_get("themes.xml?api-key=foo").
       to_return(:body => fixture("themes.xml"))
     response = @client.themes
-    response.themes.first.first.should == 'theme'
+    expect(response.themes.first.first).to eq('theme')
   end
   
   it "should return a specific theme in xml" do
@@ -39,7 +39,7 @@ describe TedApi::Client::Themes do
     stub_get("themes/1.xml?api-key=foo").
       to_return(:body => fixture("theme.xml"))
     response = @client.themes('1')
-    response.theme.slug.should == 'the_creative_spark'
+    expect(response.theme.slug).to eq('the_creative_spark')
   end
   
   

--- a/spec/ted_api/client_spec.rb
+++ b/spec/ted_api/client_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe TedApi::Client do
   it 'should instantiate with api key' do
-    proc {
+    expect{proc {
       TedApi::Client.new(api_key: 'foo')
-    }.should_not raise_exception
+    }}.to_not raise_exception
   end
 
   describe "api_endpoint" do
@@ -14,13 +14,13 @@ describe TedApi::Client do
 
     it "should default to https://api.ted.com/" do
       client = TedApi::Client.new
-      client.api_endpoint.should == 'https://api.ted.com/'
+      expect(client.api_endpoint).to eq('https://api.ted.com/')
     end
 
     it "should be set " do
       TedApi.api_endpoint = 'http://foo.dev'
       client = TedApi::Client.new
-      client.api_endpoint.should == 'http://foo.dev/'
+      expect(client.api_endpoint).to eq('http://foo.dev/')
     end
   end
 end

--- a/spec/ted_api_spec.rb
+++ b/spec/ted_api_spec.rb
@@ -8,13 +8,13 @@ describe TedApi do
 
   describe ".respond_to?" do
     it "should be true if method exists" do
-      TedApi.respond_to?(:new, true).should be_true
+      expect(TedApi.respond_to?(:new, true)).to be
     end
   end
 
   describe ".new" do
     it "should be a TedApi::Client" do
-      TedApi.new.should be_a TedApi::Client
+      expect(TedApi.new).to be_instance_of(TedApi::Client)
     end
   end
 

--- a/ted_api.gemspec
+++ b/ted_api.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   
-  gem.add_dependency 'faraday', '~> 0.8.4'
-  gem.add_dependency 'faraday_middleware', '~> 0.8.4'
+  gem.add_dependency 'faraday', '~> 0.9.0'
+  gem.add_dependency 'faraday_middleware', '~> 0.9.0'
   gem.add_dependency 'hashie', '~> 1.2'
   gem.add_dependency 'multi_json', '~> 1.3'
   gem.add_dependency 'multi_xml', '~> 0.5.0'

--- a/ted_api.gemspec
+++ b/ted_api.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   
-  gem.add_dependency 'faraday', '~> 0.9.0'
-  gem.add_dependency 'faraday_middleware', '~> 0.9.0'
-  gem.add_dependency 'hashie', '~> 1.2'
-  gem.add_dependency 'multi_json', '~> 1.3'
-  gem.add_dependency 'multi_xml', '~> 0.5.0'
+  gem.add_dependency 'faraday', '~> 0.9.1'
+  gem.add_dependency 'faraday_middleware', '~> 0.9.1'
+  gem.add_dependency 'hashie', '~> 3.4'
+  gem.add_dependency 'multi_json', '~> 1.11'
+  gem.add_dependency 'multi_xml', '~> 0.5.5'
   
   gem.add_development_dependency 'json'
   gem.add_development_dependency 'maruku'


### PR DESCRIPTION
- Updated gem dependencies to latest version of the gems.
- Updated the specs to use the new :expect syntax as opposed to the deprecated :should syntax.
